### PR TITLE
Fix typo in sec_products_of_sets.ptx

### DIFF
--- a/source/sec_products_of_sets.ptx
+++ b/source/sec_products_of_sets.ptx
@@ -72,6 +72,6 @@
       f\colon S \to \prod_{a\in A}U_a
     </me>
     such that <m>\pi_a\circ f=f_a</m>.
-    Indeed, the map <m>f</m> is given by the assignment <m>s \mapsto (f_a(x))_{a\in A}</m>.
+    Indeed, the map <m>f</m> is given by the assignment <m>s \mapsto (f_a(s))_{a\in A}</m>.
   </p>
 </section>


### PR DESCRIPTION
The variable x is undefined in ```s \mapsto (f_a(x))_{a\in A}```; is this meant to be ```s \mapsto (f_a(s))_{a\in A}``` ?